### PR TITLE
on scatterplots, allow seaborn 0.11.2 to also put Pearson's r on the …

### DIFF
--- a/bin/scatter_plots.py
+++ b/bin/scatter_plots.py
@@ -31,7 +31,12 @@ def scatter_plot(TPM_log, TPMs, name_1, name_2, lim_plot, organism):
     # calculate pearson's correlation coefficient
     stat = lambda a,b: stats.pearsonr(TPMs.rep1,TPMs.rep2)
     # add label with pearson's correlation coefficient
-    g1 =g1.annotate(stat, template="{stat}: {val:.4f}", stat="Pearson's r", loc="upper left", fontsize=15)  # {stat}: {val:.2f} (p = {p:.3g}) with p-value
+    # g1 =g1.annotate(stat, template="{stat}: {val:.4f}", stat="Pearson's r", loc="upper left", fontsize=15)  # {stat}: {val:.2f} (p = {p:.3g}) with p-value
+    # that 0.9.0 only, the following should ALSO work for v0.11.2
+    pearr = stats.pearsonr(TPMs.rep1, TPMs.rep2)
+    st=f"Pearson's r = {pearr[0]:.4f}"
+    g1.ax_joint.text(0.05, 0.95, st, fontsize=15, transform=g1.ax_joint.transAxes, verticalalignment='top')
+    # return to main
     g1.ax_marg_x.set_axis_off()
     g1.ax_marg_y.set_axis_off()
     plt.xlabel(r'$\mathrm{log_{10}TPM}$'+ '\n' + '\n' +  name_1.split('_TPM')[0] ,fontsize=15, labelpad= 5)


### PR DESCRIPTION
…top left of the plots

<!--
# nf-core/dualrnaseq pull request

Many thanks for contributing to nf-core/dualrnaseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/dualrnaseq/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
 - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/dualrnaseq/tree/master/.github/CONTRIBUTING.md)
 - [ ] If necessary, also make a PR on the nf-core/dualrnaseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint .`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
