### PR TITLE
Dualrnaseq 45 update salmon

### DIFF
--- a/conf/test_hackathon.config
+++ b/conf/test_hackathon.config
@@ -27,6 +27,7 @@ params {
     fasta_host  = "https://github.com/nf-core/test-datasets/raw/dualrnaseq/references/GRCh38.p13_sub.fasta"
     gff_host = "https://github.com/nf-core/test-datasets/raw/dualrnaseq/references/Human_gencode.v33_sub.gff3"
     gff_host_tRNA = ""
+    transcript_fasta = "data/SL1344_sub_transcriptome.fasta"
 
  //   fasta_pathogen  = "https://github.com/nf-core/test-datasets/raw/dualrnaseq/references/SL1344_sub.fasta"
  //   gff_pathogen = "https://github.com/nf-core/test-datasets/raw/dualrnaseq/references/SL1344_sub.gff3"

--- a/modules.json
+++ b/modules.json
@@ -19,6 +19,16 @@
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
                         "installed_by": ["modules"]
+                    },
+                    "salmon/index": {
+                        "branch": "master",
+                        "git_sha": "5d2c0dd6a8e2790e7ff511f7f4d761f4ed627a91",
+                        "installed_by": ["modules"]
+                    },
+                    "salmon/quant": {
+                        "branch": "master",
+                        "git_sha": "5d2c0dd6a8e2790e7ff511f7f4d761f4ed627a91",
+                        "installed_by": ["modules"]
                     }
                 }
             }

--- a/modules/nf-core/salmon/index/main.nf
+++ b/modules/nf-core/salmon/index/main.nf
@@ -1,0 +1,47 @@
+process SALMON_INDEX {
+    tag "$transcript_fasta"
+    label "process_medium"
+
+    conda "bioconda::salmon=1.10.1"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/salmon:1.10.1--h7e5ed60_0' :
+        'quay.io/biocontainers/salmon:1.10.1--h7e5ed60_0' }"
+
+    input:
+    path genome_fasta
+    path transcript_fasta
+
+    output:
+    path "salmon"      , emit: index
+    path "versions.yml", emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def get_decoy_ids = "grep '^>' $genome_fasta | cut -d ' ' -f 1 | cut -d \$'\\t' -f 1 > decoys.txt"
+    def gentrome      = "gentrome.fa"
+    if (genome_fasta.endsWith('.gz')) {
+        get_decoy_ids = "grep '^>' <(gunzip -c $genome_fasta) | cut -d ' ' -f 1 | cut -d \$'\\t' -f 1 > decoys.txt"
+        gentrome      = "gentrome.fa.gz"
+    }
+    """
+    $get_decoy_ids
+    sed -i.bak -e 's/>//g' decoys.txt
+    cat $transcript_fasta $genome_fasta > $gentrome
+
+    salmon \\
+        index \\
+        --threads $task.cpus \\
+        -t $gentrome \\
+        -d decoys.txt \\
+        $args \\
+        -i salmon
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        salmon: \$(echo \$(salmon --version) | sed -e "s/salmon //g")
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/salmon/index/meta.yml
+++ b/modules/nf-core/salmon/index/meta.yml
@@ -1,0 +1,36 @@
+name: salmon_index
+description: Create index for salmon
+keywords:
+  - index
+  - fasta
+  - genome
+  - reference
+tools:
+  - salmon:
+      description: |
+        Salmon is a tool for wicked-fast transcript quantification from RNA-seq data
+      homepage: https://salmon.readthedocs.io/en/latest/salmon.html
+      manual: https://salmon.readthedocs.io/en/latest/salmon.html
+      doi: 10.1038/nmeth.4197
+      licence: ["GPL-3.0-or-later"]
+input:
+  - genome_fasta:
+      type: file
+      description: Fasta file of the reference genome
+  - transcriptome_fasta:
+      type: file
+      description: Fasta file of the reference transcriptome
+
+output:
+  - index:
+      type: directory
+      description: Folder containing the star index files
+      pattern: "salmon"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+
+authors:
+  - "@kevinmenden"
+  - "@drpatelh"

--- a/modules/nf-core/salmon/quant/main.nf
+++ b/modules/nf-core/salmon/quant/main.nf
@@ -1,0 +1,77 @@
+process SALMON_QUANT {
+    tag "$meta.id"
+    label "process_medium"
+
+    conda "bioconda::salmon=1.10.1"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/salmon:1.10.1--h7e5ed60_0' :
+        'quay.io/biocontainers/salmon:1.10.1--h7e5ed60_0' }"
+
+    input:
+    tuple val(meta), path(reads)
+    path  index
+    path  gtf
+    path  transcript_fasta
+    val   alignment_mode
+    val   lib_type
+
+    output:
+    tuple val(meta), path("${prefix}") , emit: results
+    tuple val(meta), path("*info.json"), emit: json_info, optional: true
+    path  "versions.yml"               , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args   ?: ''
+    prefix   = task.ext.prefix ?: "${meta.id}"
+
+    def reference   = "--index $index"
+    def input_reads = meta.single_end ? "-r $reads" : "-1 ${reads[0]} -2 ${reads[1]}"
+    if (alignment_mode) {
+        reference   = "-t $transcript_fasta"
+        input_reads = "-a $reads"
+    }
+
+    def strandedness_opts = [
+        'A', 'U', 'SF', 'SR',
+        'IS', 'IU' , 'ISF', 'ISR',
+        'OS', 'OU' , 'OSF', 'OSR',
+        'MS', 'MU' , 'MSF', 'MSR'
+    ]
+    def strandedness =  'A'
+    if (lib_type) {
+        if (strandedness_opts.contains(lib_type)) {
+            strandedness = lib_type
+        } else {
+            log.info "[Salmon Quant] Invalid library type specified '--libType=${lib_type}', defaulting to auto-detection with '--libType=A'."
+        }
+    } else {
+        strandedness = meta.single_end ? 'U' : 'IU'
+        if (meta.strandedness == 'forward') {
+            strandedness = meta.single_end ? 'SF' : 'ISF'
+        } else if (meta.strandedness == 'reverse') {
+            strandedness = meta.single_end ? 'SR' : 'ISR'
+        }
+    }
+    """
+    salmon quant \\
+        --geneMap $gtf \\
+        --threads $task.cpus \\
+        --libType=$strandedness \\
+        $reference \\
+        $input_reads \\
+        $args \\
+        -o $prefix
+
+    if [ -f $prefix/aux_info/meta_info.json ]; then
+        cp $prefix/aux_info/meta_info.json "${prefix}_meta_info.json"
+    fi
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        salmon: \$(echo \$(salmon --version) | sed -e "s/salmon //g")
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/salmon/quant/meta.yml
+++ b/modules/nf-core/salmon/quant/meta.yml
@@ -1,0 +1,60 @@
+name: salmon_quant
+description: gene/transcript quantification with Salmon
+keywords:
+  - index
+  - fasta
+  - genome
+  - reference
+tools:
+  - salmon:
+      description: |
+        Salmon is a tool for wicked-fast transcript quantification from RNA-seq data
+      homepage: https://salmon.readthedocs.io/en/latest/salmon.html
+      manual: https://salmon.readthedocs.io/en/latest/salmon.html
+      doi: 10.1038/nmeth.4197
+      licence: ["GPL-3.0-or-later"]
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - reads:
+      type: file
+      description: |
+        List of input FastQ files of size 1 and 2 for single-end and paired-end data,
+        respectively.
+  - index:
+      type: directory
+      description: Folder containing the star index files
+  - gtf:
+      type: file
+      description: GTF of the reference transcriptome
+  - transcriptome_fasta:
+      type: file
+      description: Fasta file of the reference transcriptome
+  - alignment_mode:
+      type: boolean
+      description: whether to run salmon in alignment mode
+  - lib_type:
+      type: string
+      description: |
+        Override library type inferred based on strandedness defined in meta object
+
+output:
+  - results:
+      type: directory
+      description: Folder containing the quantification results for a specific sample
+      pattern: "${prefix}"
+  - json_info:
+      type: file
+      description: File containing meta information from Salmon quant
+      pattern: "*info.json"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+
+authors:
+  - "@kevinmenden"
+  - "@drpatelh"

--- a/subworkflows/local/salmon_selective_alignment.nf
+++ b/subworkflows/local/salmon_selective_alignment.nf
@@ -1,0 +1,24 @@
+include { SALMON_INDEX      } from '../../modules/nf-core/salmon/index/main'
+include { SALMON_QUANT     } from '../../modules/nf-core/salmon/quant/main'
+
+workflow SALMON_SELECTIVE_ALIGNMENT {
+
+    take:
+    ch_reads            // channel: [ val(meta), [ reads ] ]
+    ch_genome_fasta     // channel: /path/to/genome.fasta
+    ch_transcript_fasta // channel: /path/to/transcript.fasta
+    ch_gtf              // channel: /path/to/genome.gtf
+
+    main:
+    ch_versions = Channel.empty()
+    ch_salmon_index = Channel.empty()
+    ch_salmon_index = SALMON_INDEX ( ch_genome_fasta, ch_transcript_fasta ).index
+    ch_versions = ch_versions.mix(SALMON_INDEX.out.versions)
+
+    ch_salmon_quant = Channel.empty()
+    def alignment_mode = false
+    SALMON_QUANT(ch_reads, ch_salmon_index, ch_gtf, ch_transcript_fasta, alignment_mode, params.libtype)
+
+    emit:
+    versions = ch_versions                     // channel: [ versions.yml ]
+}

--- a/workflows/dualrnaseq.nf
+++ b/workflows/dualrnaseq.nf
@@ -38,6 +38,7 @@ ch_multiqc_custom_methods_description = params.multiqc_methods_description ? fil
 // SUBWORKFLOW: Consisting of a mix of local and nf-core/modules
 //
 include { INPUT_CHECK } from '../subworkflows/local/input_check'
+include { SALMON_SELECTIVE_ALIGNMENT } from '../subworkflows/local/salmon_selective_alignment'
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -80,6 +81,22 @@ workflow DUALRNASEQ {
         INPUT_CHECK.out.reads
     )
     ch_versions = ch_versions.mix(FASTQC.out.versions.first())
+
+    //
+    // SUBWORKFLOW: Create salmon index and run the quantification
+    //
+    ch_genome_fasta     = Channel.fromPath(params.fasta_host, checkIfExists: true)
+    ch_transcript_fasta = Channel.fromPath(params.transcript_fasta, checkIfExists: true)
+    // TODO change to gff in the future
+    ch_gtf              = Channel.fromPath(params.gff_host, checkIfExists: true)
+
+    SALMON_SELECTIVE_ALIGNMENT (
+        INPUT_CHECK.out.reads,
+        ch_genome_fasta,
+        ch_transcript_fasta,
+        ch_gtf
+    )
+    ch_versions = ch_versions.mix(SALMON_SELECTIVE_ALIGNMENT.out.versions)
 
     CUSTOM_DUMPSOFTWAREVERSIONS (
         ch_versions.unique().collectFile(name: 'collated_versions.yml')


### PR DESCRIPTION
# nf-core/dualrnaseq feature request

Migrate salmon index and salmon quantification from DSL1 to DSL2.

## Is your feature request related to a problem? Please describe
Dual RNA-seq pipeline uses DSL1. As a part of DSL2 migration effort salmon index and quantification must be migrated to DSL2.

## Describe the solution you'd like
Salmon index and quantification are already publicly available nf-core modules. These were integrated to the pipeline.


## Describe alternatives you've considered
Since there are nf-core salmon modules, there are not better solutions than to integrate them to the pipeline.

## Additional context

https://github.com/nf-core/dualrnaseq/issues/45