### PR TITLE
upgrade to nextflow v25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         NXF_VER:
-          - "24.04.2"
+          - "^25.04.2"
           - "latest-everything"
         profile:
           - "conda"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         NXF_VER:
-          - "^25.04.2"
+          - "25.04.2"
           - "latest-everything"
         profile:
           - "conda"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![AWS CI](https://img.shields.io/badge/CI%20tests-full%20size-FF9900?labelColor=000000&logo=Amazon%20AWS)](https://nf-co.re/dualrnaseq/results)[![Cite with Zenodo](http://img.shields.io/badge/DOI-10.5281/zenodo.XXXXXXX-1073c8?labelColor=000000)](https://doi.org/10.5281/zenodo.XXXXXXX)
 
-[![Nextflow](https://img.shields.io/badge/nextflow%20DSL2-%E2%89%A524.04.2-23aa62.svg)](https://www.nextflow.io/)
+[![Nextflow](https://img.shields.io/badge/nextflow%20DSL2-%E2%89%A525.04.2-23aa62.svg)](https://www.nextflow.io/)
 [![run with conda](http://img.shields.io/badge/run%20with-conda-3EB049?labelColor=000000&logo=anaconda)](https://docs.conda.io/en/latest/)
 [![run with docker](https://img.shields.io/badge/run%20with-docker-0db7ed?labelColor=000000&logo=docker)](https://www.docker.com/)
 [![run with singularity](https://img.shields.io/badge/run%20with-singularity-1d355c.svg?labelColor=000000)](https://sylabs.io/docs/)

--- a/nextflow.config
+++ b/nextflow.config
@@ -15,16 +15,14 @@ manifest {
     homePage        = 'https://github.com/nf-core/dualrnaseq'
     description     = """Dual RNA-seq pipeline"""
     mainScript      = 'main.nf'
-    nextflowVersion = '!>=24.04.2'
+    nextflowVersion = '!>=25.04.2'
     version         = '2.0dev'
     doi             = ''
 }
 
 
-
 // Global default params, used in configs
 params {
-
 
     // --------------
     // Input/Output options
@@ -64,11 +62,7 @@ params {
     pathogen_gff                                        = null
 
     // Misc
-    //genome                     = null
-
-
-
-    // Misc
+    // genome                     = null
     // read_transcriptome_fasta_host_from_file = false
     // read_transcriptome_fasta_pathogen_from_file = false
 
@@ -88,15 +82,11 @@ params {
 
     // tools to run
     fastqc                                              = true
-
     cutadapt                                            = true
-
     salmon_sa                                           = true
     salmon_ab                                           = false
-
     star                                                = false
     htseq                                               = false
-
     mapping_stats                                       = true
 
     // TODO: replace these with new nf-core standard
@@ -110,13 +100,9 @@ params {
     // --------------
     // Salmon general parameters
     // --------------
-    // gene_feature_gff_to_create_transcriptome_host   = ["exon"] // old
     libtype                                             = 'A'
-    // new
     gene_feature_gff_to_create_transcriptome_host       = "exon"
-    // gene_feature_gff_to_create_transcriptome_pathogen = ["gene", "sRNA", "tRNA", "rRNA"] //old
     gene_attribute_gff_to_create_transcriptome_host     = "transcript_id"
-    // new
     gene_feature_gff_to_create_transcriptome_pathogen   = "gene,sRNA,tRNA,rRNA"
     gene_attribute_gff_to_create_transcriptome_pathogen = "locus_tag"
 
@@ -131,6 +117,7 @@ params {
     // --------------
     salmon_sa_index_args                                = '-k 21'
     salmon_sa_args                                      = '--softclipOverhangs'
+
 
     // --------------
     // STAR general parameters
@@ -168,13 +155,11 @@ params {
 
     // Features to be extracted from each GFF file
     // Host
-    // hts_host_gff_gene_feature_to_count = ["gene"] // old
     // Features from 3rd column in GFF to use
     hts_host_gff_gene_feature_to_count                  = "gene"
     // Gene attributes from the 9th column in GFF to use
     hts_host_gff_gene_attribute                         = "gene_id"
     // Pathogen
-    // hts_pathogen_gff_gene_feature_to_count = ["gene", "sRNA", "tRNA", "rRNA"] // old
     // Features from 3rd column in GFF to use
     hts_pathogen_gff_gene_feature_to_count              = "gene,sRNA,tRNA,rRNA"
     // Gene attributes from the 9th column in GFF to use
@@ -189,6 +174,7 @@ params {
     multiqc_logo                                        = null
     max_multiqc_email_size                              = '25.MB'
     multiqc_methods_description                         = null
+
 
     // --------------
     // Boilerplate options
@@ -419,33 +405,30 @@ includeConfig !System.getenv('NXF_OFFLINE') && params.custom_config_base ? "${pa
 
 env {
     PYTHONNOUSERSITE = 1
-    R_PROFILE_USER = "/.Rprofile"
-    R_ENVIRON_USER = "/.Renviron"
+    R_PROFILE_USER   = "/.Rprofile"
+    R_ENVIRON_USER   = "/.Renviron"
     JULIA_DEPOT_PATH = "/usr/local/share/julia"
 }
 
-// --------------
+
 // Capture exit codes from upstream processes when piping
-// --------------
 process.shell = ['/bin/bash', '-euo', 'pipefail']
 
-
-def trace_timestamp = new java.util.Date().format( 'yyyy-MM-dd_HH-mm-ss')
 timeline {
     enabled = true
-    file    = "${params.outdir}/pipeline_info/execution_timeline_${trace_timestamp}.html"
+    file    = "${params.outdir}/pipeline_info/execution_timeline_${params.trace_report_suffix}.html"
 }
 report {
     enabled = true
-    file    = "${params.outdir}/pipeline_info/execution_report_${trace_timestamp}.html"
+    file    = "${params.outdir}/pipeline_info/execution_report_${params.trace_report_suffix}.html"
 }
 trace {
     enabled = true
-    file    = "${params.outdir}/pipeline_info/execution_trace_${trace_timestamp}.txt"
+    file    = "${params.outdir}/pipeline_info/execution_trace_${params.trace_report_suffix}.txt"
 }
 dag {
     enabled = true
-    file    = "${params.outdir}/pipeline_info/pipeline_dag_${trace_timestamp}.html"
+    file    = "${params.outdir}/pipeline_info/pipeline_dag_${params.trace_report_suffix}.html"
 }
 
 
@@ -454,70 +437,22 @@ dag {
 // --------------
 includeConfig 'conf/modules.config'
 
-
-// --------------
-// Function to ensure that resource requirements don't go beyond
-// a maximum limit
-// --------------
-def check_max(obj, type) {
-    if (type == 'memory') {
-        try {
-            if (obj.compareTo(params.max_memory as nextflow.util.MemoryUnit) == 1)
-                return params.max_memory as nextflow.util.MemoryUnit
-            else
-                return obj
-        } catch (all) {
-            println "   ### ERROR ###   Max memory '${params.max_memory}' is not valid! Using default value: $obj"
-            return obj
-        }
-    } else if (type == 'time') {
-        try {
-            if (obj.compareTo(params.max_time as nextflow.util.Duration) == 1)
-                return params.max_time as nextflow.util.Duration
-            else
-                return obj
-        } catch (all) {
-            println "   ### ERROR ###   Max time '${params.max_time}' is not valid! Using default value: $obj"
-            return obj
-        }
-    } else if (type == 'cpus') {
-        try {
-            return Math.min( obj, params.max_cpus as int )
-        } catch (all) {
-            println "   ### ERROR ###   Max cpus '${params.max_cpus}' is not valid! Using default value: $obj"
-            return obj
-        }
-    }
-}
-
-
 validation {
-
     // put values in here to ignore during linting
-    defaultIgnoreParams = ["genomes",
-                            "fasta",
-                            "max_cpus",
-                            "max_memory",
-                            "max_time",
-                            // hiding these 4, as the linter has a bug with the array
-                            // The pipeline needs an array to run, but the linter doesn't like it
-                            // and requires strings. But if you change to a string, the linting works
-                            //  but the pipeline asks for arrays
-                            // Salmon
-                            "gene_feature_gff_to_create_transcriptome_host",
-                            "gene_feature_gff_to_create_transcriptome_pathogen",
-                            "gene_feature_gff_to_quantify_host",
-                            "gene_feature_gff_to_quantify_pathogen",
-                            // HTSeq
-                            "hts_host_gff_gene_feature_to_count",
-                            "hts_pathogen_gff_gene_feature_to_count"
-                            ]
+    // FIXME: hiding gene_feature_gff_* because of linter bug
+    defaultIgnoreParams = [
+        "genomes",
+        "fasta",
+        "max_cpus",
+        "max_memory",
+        "max_time",
+    ]
     help {
-        enabled = true
-        command = "nextflow run $manifest.name -profile <docker/singularity/.../institute> --input samplesheet.csv --outdir <OUTDIR>"
-        fullParameter = "help_full"
+        enabled             = true
+        command             = "nextflow run ${manifest.name} -profile <docker/singularity/.../institute> --input samplesheet.csv --outdir <OUTDIR>"
+        fullParameter       = "help_full"
         showHiddenParameter = "show_hidden"
-        beforeText = """
+        beforeText          = """
 -\033[2m----------------------------------------------------\033[0m-
                                         \033[0;32m,--.\033[0;30m/\033[0;32m,-.\033[0m
 \033[0;34m        ___     __   __   __   ___     \033[0;32m/,-._.--~\'\033[0m
@@ -527,7 +462,7 @@ validation {
 \033[0;35m  ${manifest.name} ${manifest.version}\033[0m
 -\033[2m----------------------------------------------------\033[0m-
 """
-        afterText = """${manifest.doi ? "\n* The pipeline\n" : ""}${manifest.doi.tokenize(",").collect { "    https://doi.org/${it.trim().replace('https://doi.org/','')}"}.join("\n")}${manifest.doi ? "\n" : ""}
+        afterText           = """${manifest.doi ? "\n* The pipeline\n" : ""}${manifest.doi.tokenize(",").collect { "    https://doi.org/${it.trim().replace('https://doi.org/', '')}" }.join("\n")}${manifest.doi ? "\n" : ""}
 * The nf-core framework
     https://doi.org/10.1038/s41587-020-0439-x
 
@@ -537,41 +472,6 @@ validation {
     }
     summary {
         beforeText = validation.help.beforeText
-        afterText = validation.help.afterText
+        afterText  = validation.help.afterText
     }
 }
-
-validation {
-    defaultIgnoreParams = ["genomes"]
-    monochromeLogs = params.monochrome_logs
-    help {
-        enabled = true
-        command = "nextflow run nf-core/dualrnaseq -profile <docker/singularity/.../institute> --input samplesheet.csv --outdir <OUTDIR>"
-        fullParameter = "help_full"
-        showHiddenParameter = "show_hidden"
-        beforeText = """
--\033[2m----------------------------------------------------\033[0m-
-                                        \033[0;32m,--.\033[0;30m/\033[0;32m,-.\033[0m
-\033[0;34m        ___     __   __   __   ___     \033[0;32m/,-._.--~\'\033[0m
-\033[0;34m  |\\ | |__  __ /  ` /  \\ |__) |__         \033[0;33m}  {\033[0m
-\033[0;34m  | \\| |       \\__, \\__/ |  \\ |___     \033[0;32m\\`-._,-`-,\033[0m
-                                        \033[0;32m`._,._,\'\033[0m
-\033[0;35m  nf-core/dualrnaseq ${manifest.version}\033[0m
--\033[2m----------------------------------------------------\033[0m-
-"""
-        afterText = """${manifest.doi ? "\n* The pipeline\n" : ""}${manifest.doi.tokenize(",").collect { "    https://doi.org/${it.trim().replace('https://doi.org/','')}"}.join("\n")}${manifest.doi ? "\n" : ""}
-* The nf-core framework
-    https://doi.org/10.1038/s41587-020-0439-x
-
-* Software dependencies
-    https://github.com/nf-core/dualrnaseq/blob/master/CITATIONS.md
-"""
-    }
-    summary {
-        beforeText = validation.help.beforeText
-        afterText = validation.help.afterText
-    }
-}
-
-// Load modules.config for DSL2 module specific options
-includeConfig 'conf/modules.config'


### PR DESCRIPTION
## Overview

Update to get the pipeline nextflow version `^25.04.2` compatible which ended up just being a bit of config refactoring
- refactored `nextflow.config`
- `nextflow lint .` still very broken but that seems to be the case for nf-core pipelines in general at the moment as I don't think even nextflow knows what its trying to do with strict syntax yet

I tested with nextflow versions `25.04.2`/`.3`/`.4` and all worked

also removed unused/commented out code related to inputs being `string`/`array` as you seem to have found a good workaround and the `// old` `// new` comments were a bit confusing I thought. Let me know if that's an issue @reganhayward :+1:

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
 - [x] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
 - [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/dualrnaseq/tree/master/.github/CONTRIBUTING.md)
 - [x] If necessary, also make a PR on the nf-core/dualrnaseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint .`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).