### PR TITLE
Add stubs to local modules

### DIFF
--- a/modules/local/collate_processed_reads/main.nf
+++ b/modules/local/collate_processed_reads/main.nf
@@ -18,4 +18,9 @@ process COLLATE_PROCESSED_READS {
     # Concatenate all partial result files into the master file
     cat ${partial_results.join(' ')} > total_processed_reads.tsv
     """
+
+    stub:
+    """
+    touch total_processed_reads.tsv
+    """
 }

--- a/modules/local/combine_files/main.nf
+++ b/modules/local/combine_files/main.nf
@@ -15,4 +15,9 @@ process COMBINE_FILES {
     """
     cat ${file1} ${file2} > ${output_file}
     """
+
+    stub:
+    """
+    touch ${output_file}
+    """
 }

--- a/modules/local/combine_quantification_results_hts/main.nf
+++ b/modules/local/combine_quantification_results_hts/main.nf
@@ -19,4 +19,9 @@ process COMBINE_QUANTIFICATION_RESULTS_HTS {
         -a ${gene_attribute} \
         -org ${organism}
     """
+
+    stub:
+    """
+    touch combined_${organism.tsv}
+    """
 }

--- a/modules/local/combine_quantification_results_salmon/main.nf
+++ b/modules/local/combine_quantification_results_salmon/main.nf
@@ -19,4 +19,9 @@ process COMBINE_QUANTIFICATION_RESULTS_SALMON {
         -a ${params.gene_attribute_gff_to_create_transcriptome_host} \
         -org ${organism}
     """
+
+    stub:
+    """
+    touch combined_${organism}.tsv
+    """
 }

--- a/modules/local/create_transcriptome_fasta/main.nf
+++ b/modules/local/create_transcriptome_fasta/main.nf
@@ -17,4 +17,9 @@ process CREATE_TRANSCRIPTOME_FASTA {
     """
         python ${workflow.projectDir}/bin/gff_to_fasta_transcriptome.py -fasta ${fasta} -gff ${gff}  -f ${features} -a ${attribute} -o ${outfile_name}
         """
+    
+    stub:
+    """
+    touch ${outfile_name}
+    """
 }

--- a/modules/local/create_transcriptome_fasta/main.nf
+++ b/modules/local/create_transcriptome_fasta/main.nf
@@ -15,9 +15,9 @@ process CREATE_TRANSCRIPTOME_FASTA {
     script:
     outfile_name = gff[0].toString().replaceAll(/.gff3|.gff/, "_transcriptome.fasta")
     """
-        python ${workflow.projectDir}/bin/gff_to_fasta_transcriptome.py -fasta ${fasta} -gff ${gff}  -f ${features} -a ${attribute} -o ${outfile_name}
-        """
-    
+    python ${workflow.projectDir}/bin/gff_to_fasta_transcriptome.py -fasta ${fasta} -gff ${gff}  -f ${features} -a ${attribute} -o ${outfile_name}
+    """
+
     stub:
     """
     touch ${outfile_name}

--- a/modules/local/create_transcriptome_fasta_gffread/main.nf
+++ b/modules/local/create_transcriptome_fasta_gffread/main.nf
@@ -18,4 +18,9 @@ process CREATE_TRANSCRIPTOME_FASTA_GFFREAD {
     """
     gffread -w ${outfile_name} -g ${fasta} ${gff}
     """
+
+    stub:
+    """
+    touch ${outfile_name}
+    """
 }

--- a/modules/local/extract_annotations/main.nf
+++ b/modules/local/extract_annotations/main.nf
@@ -42,4 +42,23 @@ process EXTRACT_ANNOTATIONS {
         python: \$(python3 --version | awk '{ print \$2 }')
     END_VERSIONS
     """
+
+    stub:  
+    // TODO: determine the output of extracted annotations
+    // TODO: figure out the details for topic versions
+    /* extract annotations produces uses organism=pathogen: ${prefix}_${gene_attribute}_${quantifier}.tsv 
+                                                  host: ${prefix}_annotations_${quantifier}.tsv */
+    def prefix = task.ext.prefix ?: "extracted_annotations_${organism}_${quantifier}"  
+    """
+    if [ ${organism} == 'host' ]; then
+        touch ${prefix}_annotations_${quantifier}.tsv
+    elif [ ${organism} == 'pathogen' ]; then
+        touch ${prefix}_${gene_attribute}_${quantifier}.tsv
+    fi 
+
+     cat <<-END_VERSIONS > versions.yml 
+    "${task.process}":
+        python: \$(python3 --version | awk '{ print \$2 }')
+    END_VERSIONS
+    """
 }

--- a/modules/local/extract_annotations/main.nf
+++ b/modules/local/extract_annotations/main.nf
@@ -43,20 +43,16 @@ process EXTRACT_ANNOTATIONS {
     END_VERSIONS
     """
 
-    stub:  
-    // TODO: determine the output of extracted annotations
-    // TODO: figure out the details for topic versions
-    /* extract annotations produces uses organism=pathogen: ${prefix}_${gene_attribute}_${quantifier}.tsv 
-                                                  host: ${prefix}_annotations_${quantifier}.tsv */
-    def prefix = task.ext.prefix ?: "extracted_annotations_${organism}_${quantifier}"  
+    stub:
+    def prefix = task.ext.prefix ?: "extracted_annotations_${organism}_${quantifier}"
     """
     if [ ${organism} == 'host' ]; then
         touch ${prefix}_annotations_${quantifier}.tsv
     elif [ ${organism} == 'pathogen' ]; then
         touch ${prefix}_${gene_attribute}_${quantifier}.tsv
-    fi 
+    fi
 
-     cat <<-END_VERSIONS > versions.yml 
+    cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         python: \$(python3 --version | awk '{ print \$2 }')
     END_VERSIONS

--- a/modules/local/extract_processed_reads/main.nf
+++ b/modules/local/extract_processed_reads/main.nf
@@ -46,4 +46,10 @@ process EXTRACT_PROCESSED_READS {
         exit 1
     fi
     """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.txt
+    """
 }

--- a/modules/local/htseq_count/main.nf
+++ b/modules/local/htseq_count/main.nf
@@ -38,7 +38,7 @@ process HTSEQ_COUNT {
     stub:
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
-    touch ${prefix}.txt
+    touch ${prefix}_counts.txt
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/replace_attribute/main.nf
+++ b/modules/local/replace_attribute/main.nf
@@ -17,4 +17,10 @@ process REPLACE_ATTRIBUTE_GFF {
     """
     ${workflow.projectDir}/bin/replace_attribute_gff.sh ${gff} ${outfile_name} ${attribute_out} ${attribute_in}
     """
+
+    stub:
+    outfile_name = gff[0].toString().replaceAll(/.gff3|.gff/, "_${attribute_out}_attribute.gff3")
+    """
+    touch ${outfile_name}
+    """
 }

--- a/modules/local/replace_gene_feature/main.nf
+++ b/modules/local/replace_gene_feature/main.nf
@@ -14,4 +14,10 @@ process REPLACE_GENE_FEATURE_GFF {
     """
     ${workflow.projectDir}/bin/replace_feature_gff.sh ${gff} ${outfile_name} ${features}
     """
+
+    stub:
+    outfile_name = gff[0].toString().replaceAll(/.gff3|.gff/, "_quant_feature.gff3")
+    """
+    touch ${outfile_name}
+    """
 }

--- a/modules/local/salmon_split_table/main.nf
+++ b/modules/local/salmon_split_table/main.nf
@@ -36,4 +36,13 @@ process SALMON_SPLIT_TABLE {
     | cat - host_quant \
     > host_quant.sf
     """
+
+    stub: // does this work?
+    """
+    touch host_quant.sf
+    touch pathogen_quant.sf
+
+    touch host_quant
+    touch pathogen_quant
+    """
 }

--- a/modules/local/tximport/main.nf
+++ b/modules/local/tximport/main.nf
@@ -21,4 +21,20 @@ process TXIMPORT {
     def args = task.ext.args ?: ''
     prefix = task.ext.prefix ?: "${meta.id}"
     template('tximport.R')
+
+    stub:
+    """
+    touch ${meta.id}_host_quant_gene_level.sf
+
+    Rscript -e "r.version <- strsplit(version[['version.string']], ' ')[[1]][3];
+                tximport.version <- as.character(packageVersion('tximport'));
+                writeLines(
+                    c(
+                        '"${task.process}":',
+                        paste('    r-base:', r.version),
+                        paste('    tximport:', tximport.version)
+                    ),
+                'versions.yml')"
+
+    """
 }

--- a/modules/nf-core/salmon/index/main.nf
+++ b/modules/nf-core/salmon/index/main.nf
@@ -58,4 +58,14 @@ process SALMON_INDEX {
         salmon: \$(echo \$(salmon --version) | sed -e "s/salmon //g")
     END_VERSIONS
     """
+
+    stub:
+    """
+    mkdir salmon_index
+    
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        salmon: \$(echo \$(salmon --version) | sed -e "s/salmon //g")
+    END_VERSIONS
+    """
 }

--- a/modules/nf-core/salmon/quant/main.nf
+++ b/modules/nf-core/salmon/quant/main.nf
@@ -85,4 +85,17 @@ process SALMON_QUANT {
         salmon: \$(echo \$(salmon --version) | sed -e "s/salmon //g")
     END_VERSIONS
     """
+
+    stub:
+    prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    mkdir -p ${prefix}/aux_info
+    touch ${prefix}/quant.sf
+    touch ${prefix}/aux_info/meta_info.json
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        salmon: \$(echo \$(salmon --version) | sed -e "s/salmon //g")
+    END_VERSIONS
+    """
 }


### PR DESCRIPTION
## Overview
Closing #121 
Runs with -profile test_local,arm,docker,[test_star_htseq/test_sa/test_ab] -stub

To allow full stub run, needed to add stubs to nf-core/modules/.
Didn't address topic channels, write tests for stubs since no module tests exist, or update out-of-date modules.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
 - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/dualrnaseq/tree/master/.github/CONTRIBUTING.md)
 - [ ] If necessary, also make a PR on the nf-core/dualrnaseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint .`).
- [X] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
